### PR TITLE
correct color typo in app.py

### DIFF
--- a/KeyboardOSI/app.py
+++ b/KeyboardOSI/app.py
@@ -89,7 +89,7 @@ def unpressspace(event=None):
 window = Tk()
 window.title("Keypress Display")
 window.geometry('505x305')
-window.config(background='blackqwesadfsfrtrasfda  ')
+window.config(background='black')
 #window.wm_attributes('-transparentcolor','black')
 
 #set photos


### PR DESCRIPTION
Instead of the color `window.config(background='black')`, you had some non-existing 'black...` color. So I removed `...`.